### PR TITLE
Adding error handling and use a borrow.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,10 @@ fn unpack_json(data: &[u8]) {
             }
             let pretty = json::stringify_pretty(resolved, PADDING);
             println!("{}", pretty);
-        },
-        Err(e) => { println!("error: {}", e); },
+        }
+        Err(e) => {
+            println!("error: {}", e);
+        }
     }
 }
 
@@ -78,8 +80,8 @@ fn make_url(args: &Args) -> String {
 }
 
 // Call out to Google's public DNS over HTTPS endpoint.
-fn run_query(args: Args) -> Result<(), curl::Error> {
-    let full_url = make_url(&args);
+fn run_query(args: &Args) -> Result<(), curl::Error> {
+    let full_url = make_url(args);
 
     let mut easy = Easy::new();
     try!(easy.url(&full_url));
@@ -95,5 +97,7 @@ fn run_query(args: Args) -> Result<(), curl::Error> {
 fn main() {
     let args: Args = Docopt::new(USAGE).and_then(|d| d.decode()).unwrap_or_else(|e| e.exit());
 
-    let _res = run_query(args);
+    run_query(&args).unwrap_or_else(|err| {
+        println!("Failed to execute query with error: {}", err);
+    });
 }


### PR DESCRIPTION
- [x] - Passes the `Args` as a borrow
- [x] - Calls `unwrap_or_else` to report any possible curl based error when `run_query` is called:  Can be tested by turning your WIFI off temporarily.
- [x] - Ran `cargo fmt`
- [x] - Remove `needless borrow`
- [x] - Removed the `let-binding` when returning the unit-value, let-binding can't be used anyway.
